### PR TITLE
Fix compile error with GCC 4.7

### DIFF
--- a/sash/variables_engine.hpp
+++ b/sash/variables_engine.hpp
@@ -137,7 +137,8 @@ public:
               // our value can in turn have variables
               parse(err, val_input, value, true);
               if (err.empty())
-                variables_.emplace(std::move(key), std::move(value));
+                variables_.insert(std::make_pair(std::move(key),
+                                                 std::move(value)));
               return;
           }
           break;


### PR DESCRIPTION
In older GCC versions such as 4.7.2 `std::map::emplace()` is missing.
